### PR TITLE
Initialize size from config in case it is not large or compact.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ hexo.extend.tag.register('spotify', function(args) {
 		url = 'spotify:' + url;
 	}
 
+	size = config.size;
 	if(config.size === 'large') {
 		size = '300x380';
 	} else if(size === 'compact') {


### PR DESCRIPTION
This initialization is necessary so size can be specified in a `<width>x<height>` format. Otherwise, if a size other than `large` or `compact` is entered, then `size` will be null and `split` will throw an error.