### PR TITLE
Adds missing iframe closing tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function renderSpotify(args) {
   const url = getUrl(args[0]);
   const [width, height] = getSize(config);
 
-  return `<iframe src="${url}" width="${width}" height="${height}" frameborder="0" allowtransparency="allowtransparency" allow="encrypted-media">`;
+  return `<iframe src="${url}" width="${width}" height="${height}" frameborder="0" allowtransparency="allowtransparency" allow="encrypted-media"></iframe>`;
 }
 
 hexo.extend.tag.register('spotify', renderSpotify);


### PR DESCRIPTION
Once I bumped my Hexo blog's packages (including hexo-renderer-marked), the Spotify widgets started to break because of the missing iframe closing tag. 